### PR TITLE
Update React imports for iOS (React 0.40)

### DIFF
--- a/ios/RNZeroconf/RNZeroconf.h
+++ b/ios/RNZeroconf/RNZeroconf.h
@@ -7,9 +7,9 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "RCTBridge.h"
-#import "RCTBridgeModule.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTBridge.h>
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventDispatcher.h>
 
 @interface RNZeroconf : NSObject <RCTBridgeModule, NSNetServiceBrowserDelegate, NSNetServiceDelegate>
 


### PR DESCRIPTION
I've made these small changes and created a new React Native project to test them. The app successfully builds and runs on both iOS and Android.
Fixes #28 