### PR TITLE
Fix RN 0.47 breaking change

### DIFF
--- a/android/src/main/java/com/balthazargronon/RCTZeroconf/ZeroconfReactPackage.java
+++ b/android/src/main/java/com/balthazargronon/RCTZeroconf/ZeroconfReactPackage.java
@@ -20,7 +20,7 @@ public class ZeroconfReactPackage implements ReactPackage {
         return new ArrayList<>();
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return new ArrayList<>();
     }


### PR DESCRIPTION
RN 0.47 removed createJSModules() and without this fix, the module as a whole will break the build